### PR TITLE
fix: correctly determine a hashref with is_dirty

### DIFF
--- a/lib/Class/Accessor/TrackDirty.pm
+++ b/lib/Class/Accessor/TrackDirty.pm
@@ -26,6 +26,7 @@ our $REVERT = 'revert';
 
 sub _is_different_deeply($$) {
     my ($ref_x, $ref_y) = @_;
+    local $Storable::canonical = 1;  # avoiding Hash Randomization
     (freeze $ref_x) ne (freeze $ref_y);
 }
 

--- a/t/store_refs.t
+++ b/t/store_refs.t
@@ -60,4 +60,16 @@ use t::SimpleEntity;
     ok ! $entity->is_dirty;
 }
 
+{
+    # [the reproducible test case] broken by Hash Randomization
+    my %value1 = map { $_ => 1 } 1 .. 100;
+    my $entity = t::SimpleEntity->from_hash(
+        key1 => \%value1,
+        key2 => [],
+    );
+    ok ! $entity->is_dirty;
+    is_deeply $entity->key1, \%value1;
+    ok ! $entity->is_dirty, 'clean, even after accessing key1';
+}
+
 done_testing;


### PR DESCRIPTION
Hash Randomization is breaking the `is_dirty` method. If you get from a field that contains a hash-ref, `is_dirty` may return a true value even if nothing has changed.

I use the `Storable` module to compare hash-refs, but I had to specify the `canonical` option to compare hash-refs correctly.

https://perldoc.perl.org/Storable#CANONICAL-REPRESENTATION

> Normally, Storable stores elements of hashes in the order they are stored internally by Perl, i.e. pseudo-randomly. If you set $Storable::canonical to some TRUE value, Storable will store hashes with the elements sorted by their key. This allows you to compare data structures by comparing their frozen representations (or even the compressed frozen representations), which can be useful for creating lookup tables for complicated queries.