### PR TITLE
revert #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ You can pass a hash-ref or hash-like list to `<new`> method.
 
 - `my $object = YourClass->new({name1 => "value1", ...});`
 
-    The instance created by `<new`> is regarded as \`dirty' if it has some nonempty
-    fields. It's because it hasn't been stored yet.
+    The instance created by `<new`> is regarded as \`dirty' since it hasn't been
+    stored yet.
 
 ### `Class::Accessor::TrackDirty->mk_tracked_accessors("name1", "name2", ...);`
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Following helper methods will be created automatically.
     instance into some place through using `<to_hash`> method.
 
     When you pass the name of a field, you can know if the field contains the same
-    value as the stored object.
+    value as the stored object. Returns `undef` if the field is not tracked,
+    otherwise returns a defined boolean value.
 
 - `my @fields = $your_object->dirty_fields;`
 

--- a/lib/Class/Accessor/TrackDirty.pm
+++ b/lib/Class/Accessor/TrackDirty.pm
@@ -138,7 +138,7 @@ sub _mk_helpers($) {
                                                                  unless $field;
 
         return unless $tracked_fields->{$field};
-        return defined $self->{$field} unless defined $self->{$RESERVED_FIELD};
+        return 1 unless defined $self->{$RESERVED_FIELD};
 
         exists $self->{$field} &&
                _is_different $self->{$field}, $self->{$RESERVED_FIELD}{$field};
@@ -258,8 +258,8 @@ You can pass a hash-ref or hash-like list to C<<new>> method.
 
 =item C<< my $object = YourClass->new({name1 => "value1", ...}); >>
 
-The instance created by C<<new>> is regarded as `dirty' if it has some nonempty
-fields. It's because it hasn't been stored yet.
+The instance created by C<<new>> is regarded as `dirty' since it hasn't been
+stored yet.
 
 =back
 

--- a/lib/Class/Accessor/TrackDirty.pm
+++ b/lib/Class/Accessor/TrackDirty.pm
@@ -278,7 +278,8 @@ Check that the instance is modified. If it's true, you should store this
 instance into some place through using C<<to_hash>> method.
 
 When you pass the name of a field, you can know if the field contains the same
-value as the stored object.
+value as the stored object. Returns C<undef> if the field is not tracked,
+otherwise returns a defined boolean value.
 
 =item C<< my @fields = $your_object->dirty_fields; >>
 

--- a/t/field-aware.t
+++ b/t/field-aware.t
@@ -9,10 +9,10 @@ use t::CasualEntity;
 for (qw(SimpleEntity TestEntity CasualEntity)) {
     {
         my $entity = "t::$_"->new({});
-        ok eq_set([$entity->dirty_fields], [qw()]), 'new entity(1)';
+        ok eq_set([$entity->dirty_fields], [qw(key1 key2)]), 'new entity(1)';
 
         $entity->key2("2016");
-        ok eq_set([$entity->dirty_fields], [qw(key2)]), 'new entity(2)';
+        ok eq_set([$entity->dirty_fields], [qw(key1 key2)]), 'new entity(2)';
 
         $entity->key1("2015");
         ok eq_set([$entity->dirty_fields], [qw(key1 key2)]), 'new entity(3)';

--- a/t/modified-each-fields.t
+++ b/t/modified-each-fields.t
@@ -10,9 +10,9 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
     {
         my $entity = "t::$_"->new({key1 => "ABC", mtime => time});
         ok $entity->is_dirty('key1'), "The field hasn't been stored";
-        ok ! $entity->is_dirty('key2'), "An empty field is clean";
+        ok $entity->is_dirty('key2');
         ok ! $entity->is_dirty('mtime'), "Isn't managed by TrackDirty";
-        ok eq_set([$entity->dirty_fields], [qw(key1)]);
+        ok eq_set([$entity->dirty_fields], [qw(key1 key2)]);
     }
 
     {

--- a/t/modified-each-fields.t
+++ b/t/modified-each-fields.t
@@ -5,13 +5,14 @@ use Test::More;
 use t::SimpleEntity;
 use t::TestEntity;
 use t::CasualEntity;
+use constant FALSE_VALUE => !!0;
 
 for (qw(SimpleEntity TestEntity CasualEntity)) {
     {
         my $entity = "t::$_"->new({key1 => "ABC", mtime => time});
         ok $entity->is_dirty('key1'), "The field hasn't been stored";
         ok $entity->is_dirty('key2');
-        ok ! $entity->is_dirty('mtime'), "Isn't managed by TrackDirty";
+        is $entity->is_dirty('mtime'), undef, "Isn't managed by TrackDirty";
         ok eq_set([$entity->dirty_fields], [qw(key1 key2)]);
     }
 
@@ -21,22 +22,22 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
             key2 => "abc",
             mtime => 1662538400,  # Wed Sep  7 08:13:20 2022 UTC
         });
-        ok ! $entity->is_dirty('key1');
-        ok ! $entity->is_dirty('key2');
-        ok ! $entity->is_dirty('mtime'), q(Isn't managed by TrackDirty (2));
+        is $entity->is_dirty('key1'), FALSE_VALUE;
+        is $entity->is_dirty('key2'), FALSE_VALUE;
+        is $entity->is_dirty('mtime'), undef, q(Isn't managed by TrackDirty (2));
         ok eq_set([$entity->dirty_fields], [qw()]);
 
         $entity->key1("XYZ");
         $entity->key2("abc");
         $entity->mtime($entity->mtime + 1);
         ok $entity->is_dirty('key1');
-        ok ! $entity->is_dirty('key2');
-        ok ! $entity->is_dirty('mtime'), q(Isn't managed by TrackDirty (3));
+        is $entity->is_dirty('key2'), FALSE_VALUE;
+        is $entity->is_dirty('mtime'), undef, q(Isn't managed by TrackDirty (3));
         ok eq_set([$entity->dirty_fields], [qw(key1)]);
 
         $entity->key1("ABC");
         $entity->key2("xyz");
-        ok ! $entity->is_dirty('key1');
+        is $entity->is_dirty('key1'), FALSE_VALUE;
         ok $entity->is_dirty('key2');
         ok eq_set([$entity->dirty_fields], [qw(key2)]);
 
@@ -46,9 +47,9 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         ok eq_set([$entity->dirty_fields], [qw(key1 key2)]);
 
         $entity->to_hash; # Will be stored into any places
-        ok ! $entity->is_dirty('key1');
-        ok ! $entity->is_dirty('key2');
-        ok ! $entity->is_dirty('mtime'), q(Isn't managed by TrackDirty (4));
+        is $entity->is_dirty('key1'), FALSE_VALUE;
+        is $entity->is_dirty('key2'), FALSE_VALUE;
+        is $entity->is_dirty('mtime'), undef, q(Isn't managed by TrackDirty (4));
         ok eq_set([$entity->dirty_fields], [qw()]);
     }
 }

--- a/t/modified-each-fields.t
+++ b/t/modified-each-fields.t
@@ -16,15 +16,22 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
     }
 
     {
-        my $entity = "t::$_"->from_hash({key1 => "ABC", key2 => "abc"});
+        my $entity = "t::$_"->from_hash({
+            key1 => "ABC",
+            key2 => "abc",
+            mtime => 1662538400,  # Wed Sep  7 08:13:20 2022 UTC
+        });
         ok ! $entity->is_dirty('key1');
         ok ! $entity->is_dirty('key2');
+        ok ! $entity->is_dirty('mtime'), q(Isn't managed by TrackDirty (2));
         ok eq_set([$entity->dirty_fields], [qw()]);
 
         $entity->key1("XYZ");
         $entity->key2("abc");
+        $entity->mtime($entity->mtime + 1);
         ok $entity->is_dirty('key1');
         ok ! $entity->is_dirty('key2');
+        ok ! $entity->is_dirty('mtime'), q(Isn't managed by TrackDirty (3));
         ok eq_set([$entity->dirty_fields], [qw(key1)]);
 
         $entity->key1("ABC");
@@ -41,6 +48,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         $entity->to_hash; # Will be stored into any places
         ok ! $entity->is_dirty('key1');
         ok ! $entity->is_dirty('key2');
+        ok ! $entity->is_dirty('mtime'), q(Isn't managed by TrackDirty (4));
         ok eq_set([$entity->dirty_fields], [qw()]);
     }
 }

--- a/t/modified.t
+++ b/t/modified.t
@@ -16,7 +16,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
 
         $entity->revert;
         is $entity->key1, undef, "All fields shoud be removed.";
-        ok ! $entity->is_dirty, "An empty entity shouldn't be stored";
+        ok $entity->is_dirty, "The new entity should be stored";
         ok $entity->is_new, "The new data";
 
         (undef) = $entity->to_hash;
@@ -26,11 +26,11 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
 
     {
         my $entity = "t::$_"->new({});
-        ok ! $entity->is_dirty, "Don't save empty data";
+        ok $entity->is_dirty, "Save empty data";
         ok $entity->is_new, "The new data";
 
         $entity->revert;
-        ok ! $entity->is_dirty, "Is reverted. Don't save empty data";
+        ok $entity->is_dirty, "Is reverted but it has not been serialized.";
         ok $entity->is_new, "The new data";
 
         $entity->key1(18);
@@ -50,7 +50,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         $entity->key1(99);  # Keep _origin field from being defined.
 
         $entity->revert;
-        ok ! $entity->is_dirty, "Is reverted. Don't save empty data";
+        ok $entity->is_dirty, "Is reverted but it has not been serialized.";
         ok $entity->is_new, "The new data";
     }
 

--- a/t/modified.t
+++ b/t/modified.t
@@ -5,6 +5,7 @@ use Test::More;
 use t::SimpleEntity;
 use t::TestEntity;
 use t::CasualEntity;
+use constant FALSE_VALUE => !!0;
 
 for (qw(SimpleEntity TestEntity CasualEntity)) {
     {
@@ -20,7 +21,8 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         ok $entity->is_new, "The new data";
 
         (undef) = $entity->to_hash;
-        ok ! $entity->is_dirty, "All modified columns are stored";
+        is $entity->is_dirty, FALSE_VALUE, "All modified columns are stored";
+        isnt $entity->is_dirty, undef, 'return a defined value';
         ok ! $entity->is_new, "Stored in a storage";
     }
 
@@ -39,7 +41,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         ok $entity->is_new, "The new data";
 
         (undef) = $entity->to_hash;
-        ok ! $entity->is_dirty, "All modified columns are stored";
+        is $entity->is_dirty, FALSE_VALUE, "All modified columns are stored";
         ok ! $entity->is_new, "Stored in a storage";
     }
 
@@ -58,17 +60,17 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         my $entity = "t::$_"->from_hash({
             key1 => 35,
         });
-        ok ! $entity->is_dirty, "need not store the loaded data";
+        is $entity->is_dirty, FALSE_VALUE, "need not store the loaded data";
         ok ! $entity->is_new, "Fetched from a storage";
         $entity->is_dirty(1);
         $entity->is_new(1);
-        ok ! $entity->is_dirty, "You can't modify is_dirty.";
+        is $entity->is_dirty, FALSE_VALUE, "You can't modify is_dirty.";
         ok ! $entity->is_new, "You can't modify is_new.";
 
         $entity->key1(35);
         $entity->key2(undef);
-        ok ! $entity->is_dirty, "I didn't change anything :p";
-        ok ! $entity->is_dirty, "I didn't change anything :p";
+        is $entity->is_dirty, FALSE_VALUE, "I didn't change anything :p";
+        is $entity->is_dirty, FALSE_VALUE, "I didn't change anything :p";
         ok ! $entity->is_new, "Fetched from a storage";
 
         $entity->key1(36);
@@ -79,8 +81,8 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
 
         $entity->key1(35);
         $entity->key2(undef);
-        ok ! $entity->is_dirty, "Finally return to the original value :p";
-        ok ! $entity->is_dirty, "Finally return to the original value :p";
+        is $entity->is_dirty, FALSE_VALUE, "Finally return to the original value :p";
+        is $entity->is_dirty, FALSE_VALUE, "Finally return to the original value :p";
         ok ! $entity->is_new, "Fetched from a storage";
 
         $entity->key1(36);
@@ -88,7 +90,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         $entity->revert;
         is $entity->key1, 35, "reverted changes";
         is $entity->key2, undef, "reverted changes";
-        ok ! $entity->is_dirty, "reverted all statuses";
+        is $entity->is_dirty, FALSE_VALUE, "reverted all statuses";
         ok ! $entity->is_new, "Fetched from a storage";
 
         # Freeze all changes
@@ -99,10 +101,10 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         my $hash = $entity->to_hash;
         is $hash->{key1}, 36;
         is $entity->key1, 36;
-        ok ! $entity->is_dirty, "Reset the is_dirty field";
+        is $entity->is_dirty, FALSE_VALUE, "Reset the is_dirty field";
         ok ! $entity->is_new, "Saved into a storage";
         is int($entity), int($entity_alias), "to_hash shouldn't break refs.";
-        ok ! $entity_alias->is_dirty, "Aliases is also cleaned.";
+        is $entity_alias->is_dirty, FALSE_VALUE, "Aliases is also cleaned.";
         ok ! $entity->is_new, "Saved into a storage";
     }
 
@@ -117,7 +119,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         $entity->mtime(1360918002);
 
         is $entity->mtime, 1360918002;
-        ok ! $entity->is_dirty, "Don't save the modification of modified";
+        is $entity->is_dirty, FALSE_VALUE, "Don't save the modification of modified";
         ok ! $entity->is_new, "Fetched from a storage";
 
         $entity->revert;
@@ -134,7 +136,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
             is_dirty => 1,
             is_new => 1,
         });
-        ok ! $entity->is_dirty, "You mustn't set is_dirty.";
+        is $entity->is_dirty, FALSE_VALUE, "You mustn't set is_dirty.";
         ok ! $entity->is_new, "You mustn't set is_new";
     }
 
@@ -144,7 +146,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         $entity->to_hash;
         $entity->to_hash;
 
-        ok ! $entity->is_dirty;
+        is $entity->is_dirty, FALSE_VALUE;
         ok ! $entity->is_new, "Fetched from a storage";
         is $entity->key1, 36;
         is $entity->key2, "hiratara";
@@ -158,11 +160,11 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
             key2 => 'hiratara',
             mtime => 1662538400,  # Wed Sep  7 08:13:20 2022 UTC
         });
-        ok ! $entity->is_dirty, 'just retrive from KVS';
+        is $entity->is_dirty, FALSE_VALUE, 'just retrive from KVS';
         ok ! $entity->is_new, 'not a new entity';
 
         $entity->mtime(undef);
-        ok ! $entity->is_dirty, q(don't care because mtime is not tracked);
+        is $entity->is_dirty, FALSE_VALUE, q(don't care because mtime is not tracked);
 
         $entity->key1(undef);
         ok $entity->is_dirty, 'modified key1';

--- a/t/modified.t
+++ b/t/modified.t
@@ -150,6 +150,28 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         is $entity->key2, "hiratara";
         is $entity->mtime, "12345";
     }
+
+    {
+        # want to make all fields undefined
+        my $entity = "t::$_"->from_hash({
+            key1 => 45,
+            key2 => 'hiratara',
+            mtime => 1662538400,  # Wed Sep  7 08:13:20 2022 UTC
+        });
+        ok ! $entity->is_dirty, 'just retrive from KVS';
+        ok ! $entity->is_new, 'not a new entity';
+
+        $entity->mtime(undef);
+        ok ! $entity->is_dirty, q(don't care because mtime is not tracked);
+
+        $entity->key1(undef);
+        ok $entity->is_dirty, 'modified key1';
+
+        $entity->key2(undef);
+        ok $entity->is_dirty, 'modified all fields';
+
+        is_deeply $entity->to_hash, {};
+    }
 }
 
 done_testing;

--- a/t/own_fields.t
+++ b/t/own_fields.t
@@ -36,7 +36,7 @@ my $now = time;
     is $hash_ref->{mtime}, $now;
     ok ! exists $hash_ref->{dummy}, "Don't store undefined fields.";
 
-    ok ! $entity->is_dirty, "Cleaned";
+    is $entity->is_dirty, !!0, "Cleaned";
     is $entity->mtime, $now, "Don't break normal fields.";
     is $entity->dummy, 30, "Don't touch to my private field.";
 }

--- a/t/raw.t
+++ b/t/raw.t
@@ -5,6 +5,7 @@ use Test::More;
 use t::SimpleEntity;
 use t::TestEntity;
 use t::CasualEntity;
+use constant FALSE_VALUE => !!0;
 
 for (qw(SimpleEntity TestEntity CasualEntity)) {
     {
@@ -27,7 +28,7 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
         is_deeply $entity->raw, {
             key1 => 37, mtime => 1389955235,
         };
-        ok ! $entity->is_dirty, "Stored all data";
+        is $entity->is_dirty, FALSE_VALUE, "Stored all data";
 
         $entity->key1(36);
         $entity->mtime(1389955234);
@@ -43,12 +44,12 @@ for (qw(SimpleEntity TestEntity CasualEntity)) {
             not_managed_by_tdirty => 'HOGEHOGE',
         });
         is_deeply $entity->raw, {key1 => 36, mtime => 1389955234};
-        ok ! $entity->is_dirty, "Fresh instance";
+        is $entity->is_dirty, FALSE_VALUE, "Fresh instance";
 
         (undef) = $entity->to_hash; # Stored into some storages
 
         is_deeply $entity->raw, {key1 => 36, mtime => 1389955234};
-        ok ! $entity->is_dirty, "Fresh instance";
+        is $entity->is_dirty, FALSE_VALUE, "Fresh instance";
     }
 }
 

--- a/t/store_refs.t
+++ b/t/store_refs.t
@@ -3,6 +3,7 @@ use warnings;
 use lib '.';
 use Test::More;
 use t::SimpleEntity;
+use constant FALSE_VALUE => !!0;
 
 {
     my $entity = t::SimpleEntity->new(
@@ -29,7 +30,7 @@ use t::SimpleEntity;
         key2 => [qw(x y)],
     );
     is $entity->key2->[1], 'y';
-    ok ! $entity->is_dirty;
+    is $entity->is_dirty, FALSE_VALUE;
 
     $entity->key1->{nested}->{count}++;
     push @{$entity->key2}, 'z';
@@ -39,7 +40,7 @@ use t::SimpleEntity;
     $entity->revert;
     is $entity->key1->{nested}->{count}, 0;
     is_deeply $entity->key2, ['x', 'y'];
-    ok ! $entity->is_dirty;
+    is $entity->is_dirty, FALSE_VALUE;
 }
 
 {
@@ -57,7 +58,7 @@ use t::SimpleEntity;
     pop @{$entity->key2};
     is $entity->key1->{nested}->{count}, 0;
     is_deeply $entity->key2, ['x', 'y'];
-    ok ! $entity->is_dirty;
+    is $entity->is_dirty, FALSE_VALUE;
 }
 
 {
@@ -67,9 +68,9 @@ use t::SimpleEntity;
         key1 => \%value1,
         key2 => [],
     );
-    ok ! $entity->is_dirty;
+    is $entity->is_dirty, FALSE_VALUE;
     is_deeply $entity->key1, \%value1;
-    ok ! $entity->is_dirty, 'clean, even after accessing key1';
+    is $entity->is_dirty, FALSE_VALUE, 'clean, even after accessing key1';
 }
 
 done_testing;

--- a/t/store_refs.t
+++ b/t/store_refs.t
@@ -20,7 +20,7 @@ use t::SimpleEntity;
     $entity->revert;
     is $entity->key1, undef;
     is $entity->key2, undef;
-    ok ! $entity->is_dirty, 'No data to store';
+    ok $entity->is_dirty;
 }
 
 {


### PR DESCRIPTION
I changed in #5 to consider a freshly created empty instance as clean, but this specification is unnatural considering the possibility of explicitly setting the value of a field to `undef`. Moreover, I don't think it is correct to consider a new instance of an untracked field with a value as clean.

I revert #5 and change the return value of `is_dirty` when called with an untracked field name to `undef` to indicate that it can't be determined.